### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/configure-entries.jelly
@@ -314,10 +314,10 @@ Portions of this code copied from the Jenkins Project. See LICENSE.md for notice
     <script>
         (function() {
         Behaviour.specify("#recurse", 'ListView', 0, function(e) {
-        var nestedElements = $$('SPAN.nested')
+        var nestedElements = document.querySelectorAll('SPAN.nested')
         e.onclick = function() {
-        nestedElements.each(function(el) {
-        e.checked ? el.show() : el.hide();
+        nestedElements.forEach(function(el) {
+        el.style.display = e.checked ? '' : 'none';
         });
         }
         });


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. A similar change was already tested in Jenkins core in jenkinsci/jenkins#7796.