### PR TITLE
[JENKINS-74178] Extract inline JavaScript from `CalendarView/main.jelly`

### DIFF
--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main.jelly
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main.jelly
@@ -49,111 +49,110 @@ THE SOFTWARE.
         }
       </style>
     </j:if>
-    <script>
-       CalendarViewOptions = {
-         defaultView: '${it.calendarViewType.name().toLowerCase()}-view',
-         buttonText: {
-           'today': '${%ButtonText.Today}',
-           'month-view': '${%ButtonText.Month}',
-           'week-view': '${%ButtonText.Week}',
-           'day-view': '${%ButtonText.Day}',
+    <script id="calendar-view-data" type="application/json">{
+         "defaultView": "${it.calendarViewType.name().toLowerCase()}-view",
+         "buttonText": {
+           "today": "${%ButtonText.Today}",
+           "month-view": "${%ButtonText.Month}",
+           "week-view": "${%ButtonText.Week}",
+           "day-view": "${%ButtonText.Day}"
          },
-         popupText: {
-           'build': '${%This build}:',
-           'buildHistory': '${%Build History}:',
-           'buildHistoryEmpty': '${%No past builds}',
-           'project': '${%Project}: ',
-           'nextScheduledBuild': '${%Next build}: ',
+         "popupText": {
+           "build": "${%This build}:",
+           "buildHistory": "${%Build History}:",
+           "buildHistoryEmpty": "${%No past builds}",
+           "project": "${%Project}: ",
+           "nextScheduledBuild": "${%Next build}: "
          },
-         names: {
-           monthNames: [
-             '${%MonthNames.January}',
-             '${%MonthNames.February}',
-             '${%MonthNames.March}',
-             '${%MonthNames.April}',
-             '${%MonthNames.May}',
-             '${%MonthNames.June}',
-             '${%MonthNames.July}',
-             '${%MonthNames.August}',
-             '${%MonthNames.September}',
-             '${%MonthNames.October}',
-             '${%MonthNames.November}',
-             '${%MonthNames.December}'
+         "names": {
+           "monthNames": [
+             "${%MonthNames.January}",
+             "${%MonthNames.February}",
+             "${%MonthNames.March}",
+             "${%MonthNames.April}",
+             "${%MonthNames.May}",
+             "${%MonthNames.June}",
+             "${%MonthNames.July}",
+             "${%MonthNames.August}",
+             "${%MonthNames.September}",
+             "${%MonthNames.October}",
+             "${%MonthNames.November}",
+             "${%MonthNames.December}"
            ],
-           monthNamesShort: [
-             '${%MonthNamesShort.Jan}',
-             '${%MonthNamesShort.Feb}',
-             '${%MonthNamesShort.Mar}',
-             '${%MonthNamesShort.Apr}',
-             '${%MonthNamesShort.May}',
-             '${%MonthNamesShort.Jun}',
-             '${%MonthNamesShort.Jul}',
-             '${%MonthNamesShort.Aug}',
-             '${%MonthNamesShort.Sep}',
-             '${%MonthNamesShort.Oct}',
-             '${%MonthNamesShort.Nov}',
-             '${%MonthNamesShort.Dec}'
+           "monthNamesShort": [
+             "${%MonthNamesShort.Jan}",
+             "${%MonthNamesShort.Feb}",
+             "${%MonthNamesShort.Mar}",
+             "${%MonthNamesShort.Apr}",
+             "${%MonthNamesShort.May}",
+             "${%MonthNamesShort.Jun}",
+             "${%MonthNamesShort.Jul}",
+             "${%MonthNamesShort.Aug}",
+             "${%MonthNamesShort.Sep}",
+             "${%MonthNamesShort.Oct}",
+             "${%MonthNamesShort.Nov}",
+             "${%MonthNamesShort.Dec}"
            ],
-           dayNames: [
-             '${%DayNames.Sunday}',
-             '${%DayNames.Monday}',
-             '${%DayNames.Tuesday}',
-             '${%DayNames.Wednesday}',
-             '${%DayNames.Thursday}',
-             '${%DayNames.Friday}',
-             '${%DayNames.Saturday}'
+           "dayNames": [
+             "${%DayNames.Sunday}",
+             "${%DayNames.Monday}",
+             "${%DayNames.Tuesday}",
+             "${%DayNames.Wednesday}",
+             "${%DayNames.Thursday}",
+             "${%DayNames.Friday}",
+             "${%DayNames.Saturday}"
            ],
-           dayNamesShort: [
-             '${%DayNamesShort.Sun}',
-             '${%DayNamesShort.Mon}',
-             '${%DayNamesShort.Tue}',
-             '${%DayNamesShort.Wed}',
-             '${%DayNamesShort.Thu}',
-             '${%DayNamesShort.Fri}',
-             '${%DayNamesShort.Sat}'
+           "dayNamesShort": [
+             "${%DayNamesShort.Sun}",
+             "${%DayNamesShort.Mon}",
+             "${%DayNamesShort.Tue}",
+             "${%DayNamesShort.Wed}",
+             "${%DayNamesShort.Thu}",
+             "${%DayNamesShort.Fri}",
+             "${%DayNamesShort.Sat}"
            ]
          },
-         weekSettings: {
-           weekends: ${(it.useCustomWeekSettings) ? it.weekSettingsShowWeekends : true},
-           weekNumbers: ${(it.useCustomWeekSettings) ? it.weekSettingsShowWeekNumbers : true},
-           firstDay: ${(it.useCustomWeekSettings) ? it.weekSettingsFirstDay : 1},
+         "weekSettings": {
+           "weekends": ${(it.useCustomWeekSettings) ? it.weekSettingsShowWeekends : true},
+           "weekNumbers": ${(it.useCustomWeekSettings) ? it.weekSettingsShowWeekNumbers : true},
+           "firstDay": ${(it.useCustomWeekSettings) ? it.weekSettingsFirstDay : 1}
          },
-         formats: {
-           'month-view': {
-             titleFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthTitleFormat) : ''}"/>' || '${%Month.TitleFormat}',
-             columnHeaderFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthColumnHeaderFormat) : ''}"/>' || '${%Month.ColumnHeaderFormat}',
-             timeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthTimeFormat) : ''}"/>' || '${%Month.TimeFormat}',
-             popupBuildTimeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthPopupBuildTimeFormat) : ''}"/>' || '${%Month.PopupBuildTimeFormat}'
+         "formats": {
+           "month-view": {
+             "titleFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthTitleFormat) : '%Month.TitleFormat'}"/>",
+             "columnHeaderFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthColumnHeaderFormat) : '%Month.ColumnHeaderFormat'}"/>",
+             "timeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthTimeFormat) : '%Month.TimeFormat'}"/>",
+             "popupBuildTimeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.monthPopupBuildTimeFormat) : '%Month.PopupBuildTimeFormat'}"/>"
            },
-           'week-view': {
-             titleFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekTitleFormat) : ''}"/>' || '${%Week.TitleFormat}',
-             columnHeaderFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekColumnHeaderFormat) : ''}"/>' || '${%Week.ColumnHeaderFormat}',
-             timeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekTimeFormat) : ''}"/>' || '${%Week.TimeFormat}',
-             slotLabelFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekSlotTimeFormat) : ''}"/>' || '${%Week.SlotLabelFormat}',
-             popupBuildTimeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekPopupBuildTimeFormat) : ''}"/>' || '${%Week.PopupBuildTimeFormat}'
+           "week-view": {
+             "titleFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekTitleFormat) : '%Week.TitleFormat'}"/>",
+             "columnHeaderFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekColumnHeaderFormat) : '%Week.ColumnHeaderFormat'}"/>",
+             "timeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekTimeFormat) : '%Week.TimeFormat'}"/>",
+             "slotLabelFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekSlotTimeFormat) : '%Week.SlotLabelFormat'}"/>",
+             "popupBuildTimeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.weekPopupBuildTimeFormat) : '%Week.PopupBuildTimeFormat'}"/>"
            },
-           'day-view': {
-             titleFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayTitleFormat) : ''}"/>' || '${%Day.TitleFormat}',
-             columnHeaderFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayColumnHeaderFormat) : ''}"/>' || '${%Day.ColumnHeaderFormat}',
-             timeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayTimeFormat) : ''}"/>' || '${%Day.TimeFormat}',
-             slotLabelFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.daySlotTimeFormat) : ''}"/>' || '${%Day.SlotLabelFormat}',
-             popupBuildTimeFormat: '<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayPopupBuildTimeFormat) : ''}"/>' || '${%Day.PopupBuildTimeFormat}'
+           "day-view": {
+             "titleFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayTitleFormat) : '%Day.TitleFormat'}"/>",
+             "columnHeaderFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayColumnHeaderFormat) : '%Day.ColumnHeaderFormat'}"/>",
+             "timeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayTimeFormat) : '%Day.TimeFormat'}"/>",
+             "slotLabelFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.daySlotTimeFormat) : '%Day.SlotLabelFormat'}"/>",
+             "popupBuildTimeFormat": "<j:out value="${it.useCustomFormats ? it.jsonEscape(it.dayPopupBuildTimeFormat) : '%Day.PopupBuildTimeFormat'}"/>"
            }
          },
-         slotSettings: {
-           'week-view': {
-             slotDuration: '${it.useCustomSlotSettings ? it.jsonEscape(it.weekSlotDuration) : ''}' || '00:30:00',
-             minTime: '${it.useCustomSlotSettings ? it.jsonEscape(it.weekMinTime) : ''}' || '00:00:00',
-             maxTime: '${it.useCustomSlotSettings ? it.jsonEscape(it.weekMaxTime) : ''}' || '24:00:00',
+         "slotSettings": {
+           "week-view": {
+             "slotDuration": "${it.useCustomSlotSettings ? it.jsonEscape(it.weekSlotDuration) : '00:30:00'}",
+             "minTime": "${it.useCustomSlotSettings ? it.jsonEscape(it.weekMinTime) : '00:00:00'}",
+             "maxTime": "${it.useCustomSlotSettings ? it.jsonEscape(it.weekMaxTime) : '24:00:00'}"
            },
-           'day-view': {
-             slotDuration: '${it.useCustomSlotSettings ? it.jsonEscape(it.daySlotDuration) : ''}' || '00:30:00',
-             minTime: '${it.useCustomSlotSettings ? it.jsonEscape(it.dayMinTime) : ''}' || '00:00:00',
-             maxTime: '${it.useCustomSlotSettings ? it.jsonEscape(it.dayMaxTime) : ''}' || '24:00:00',
+           "day-view": {
+             "slotDuration": "${it.useCustomSlotSettings ? it.jsonEscape(it.daySlotDuration) : '00:30:00'}",
+             "minTime": "${it.useCustomSlotSettings ? it.jsonEscape(it.dayMinTime) : '00:00:00'}",
+             "maxTime": "${it.useCustomSlotSettings ? it.jsonEscape(it.dayMaxTime) : '24:00:00'}"
            }
          }
-       };
-    </script>
+       }</script>
+    <st:adjunct includes="io.jenkins.plugins.view.calendar.CalendarView.resource"/>
     <script type="text/javascript" src="${rootURL}/plugin/calendar-view/bundles/calendar-view.js"></script>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/resource.js
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/resource.js
@@ -1,0 +1,1 @@
+CalendarViewOptions = JSON.parse(document.querySelector("#calendar-view-data").textContent.replace(/\n\s+/g, ""));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74178

I made the configuration object a valid JSON and changed the `script` tag to be of `type="application/json"`, which if CSP compliant AFAICT. That object is then parsed and assigned to `CalendarViewOptions` variable in a separate JS file.

The other violation that shows up in the CSP report screen is fixed in https://github.com/jenkinsci/calendar-view-plugin/pull/46.

### Testing done

[Before the change](https://www.youtube.com/watch?v=P9a6iS3wd8M)
[After the change](https://www.youtube.com/watch?v=PwfWQVSGDzQ)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
