### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.88</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -15,8 +15,8 @@
         <revision>0.3.6</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.440</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <node.version>16.20.2</node.version>
         <npm.version>8.19.4</npm.version>
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3435.v238d66a_043fb_</version>
+                <version>3944.v1a_e4f8b_452db_</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/io/jenkins/plugins/view/calendar/CalendarView.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/CalendarView.java
@@ -40,9 +40,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.*;
@@ -339,13 +339,13 @@ public class CalendarView extends ListView {
     }
 
     @Override
-    protected void submit(final StaplerRequest req) throws ServletException, Descriptor.FormException, IOException {
+    protected void submit(final StaplerRequest2 req) throws ServletException, Descriptor.FormException, IOException {
         this.validate(req);
         super.submit(req);
         this.updateFields(req);
     }
 
-    private void validate(final StaplerRequest req) throws Descriptor.FormException {
+    private void validate(final StaplerRequest2 req) throws Descriptor.FormException {
         final List<String> validSlotDurations = Collections.unmodifiableList(Arrays.asList(
             "00:05:00", "00:10:00", "00:15:00", "00:20:00", "00:30:00", "01:00:00"
         ));
@@ -364,7 +364,7 @@ public class CalendarView extends ListView {
         validatePattern(req, "dayMaxTime", validDateTimePattern);
     }
 
-    private void updateFields(final StaplerRequest req) {
+    private void updateFields(final StaplerRequest2 req) {
         setCalendarViewEventsType(CalendarViewEventsType.valueOf(req.getParameter("calendarViewEventsType")));
         setCalendarViewType(CalendarViewType.valueOf(req.getParameter("calendarViewType")));
 
@@ -414,7 +414,7 @@ public class CalendarView extends ListView {
     }
 
     public List<CalendarEvent> getEvents() throws ParseException {
-        final StaplerRequest req = Stapler.getCurrentRequest();
+        final StaplerRequest2 req = Stapler.getCurrentRequest2();
 
         final Calendar start = RequestUtil.getParamAsCalendar(req, "start");
         final Calendar end = RequestUtil.getParamAsCalendar(req, "end");

--- a/src/main/java/io/jenkins/plugins/view/calendar/util/RequestUtil.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/util/RequestUtil.java
@@ -25,7 +25,7 @@ package io.jenkins.plugins.view.calendar.util;
 
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.text.ParseException;
 import java.util.Calendar;
@@ -35,7 +35,7 @@ public final class RequestUtil {
 
     private RequestUtil() {}
 
-    public static Calendar getParamAsCalendar(final StaplerRequest req, final String param) throws ParseException {
+    public static Calendar getParamAsCalendar(final StaplerRequest2 req, final String param) throws ParseException {
         final String dateString = req.getParameter(param);
 
         final Calendar cal = Calendar.getInstance();

--- a/src/main/java/io/jenkins/plugins/view/calendar/util/ValidationUtil.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/util/ValidationUtil.java
@@ -26,7 +26,7 @@ package io.jenkins.plugins.view.calendar.util;
 import hudson.model.Descriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +37,7 @@ public final class ValidationUtil {
 
     private ValidationUtil() { }
 
-    public static void validateEnum(final StaplerRequest req, final String formField, final Class<? extends Enum> enumClass) throws Descriptor.FormException {
+    public static void validateEnum(final StaplerRequest2 req, final String formField, final Class<? extends Enum> enumClass) throws Descriptor.FormException {
         final Enum[] enumConstants = enumClass.getEnumConstants();
         for (final Enum enumConstant: enumConstants) {
             if (enumConstant.name().equals(req.getParameter(formField))) {
@@ -47,20 +47,20 @@ public final class ValidationUtil {
         throw new Descriptor.FormException(formField + " must be one of " + Arrays.asList(enumConstants), formField);
     }
 
-    public static void validateInList(final StaplerRequest req, final String formField, final List<String> possibleValues) throws Descriptor.FormException {
+    public static void validateInList(final StaplerRequest2 req, final String formField, final List<String> possibleValues) throws Descriptor.FormException {
         if (!possibleValues.contains(req.getParameter(formField))) {
             throw new Descriptor.FormException(formField + " must be one of " + possibleValues, formField);
         }
     }
 
-    public static void validatePattern(final StaplerRequest req, final String formField, final Pattern pattern) throws Descriptor.FormException {
+    public static void validatePattern(final StaplerRequest2 req, final String formField, final Pattern pattern) throws Descriptor.FormException {
         final String value = req.getParameter(formField);
         if (value == null || !pattern.matcher(value).matches()) {
             throw new Descriptor.FormException(formField + " must match " + pattern, formField);
         }
     }
 
-    public static void validateRange(final StaplerRequest req, final String formField, final int min, final int max) throws Descriptor.FormException {
+    public static void validateRange(final StaplerRequest2 req, final String formField, final int min, final int max) throws Descriptor.FormException {
         final int value = Integer.parseInt(req.getParameter("weekSettingsFirstDay"));
         if (value < min || value > max) {
             throw new Descriptor.FormException(formField + " must be: " + min + " <= " + formField + " <= " + max, formField);


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`