### PR TITLE
Fixed text-color for light-/dark-mode

### DIFF
--- a/src/main/css/index.css
+++ b/src/main/css/index.css
@@ -57,7 +57,7 @@
 .fc-event-container a.event-state-scheduled:link,
 .fc-event-container a.event-state-scheduled:active,
 .fc-event-container a.event-state-scheduled:visited {
-  color:black;
+  color: var(--text-color);
 }
 
 .fc-event {


### PR DESCRIPTION
The latest PR for a UI update, didn't consider the text colors for scheduled jobs in light-/dark-mode, so the text was very hard to read in dark-mode. This PR fixes this by using the configured text-color from the theme.

This fixes #109