### PR TITLE
Java17 is no longer supported on ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'linux', jdk: 17],
+  [platform: 'linux', jdk: 25],
 ])


### PR DESCRIPTION
Removed java17 from Jenkinsfile, added java25 instead.