### PR TITLE
Tooltip shows job parameters

### DIFF
--- a/src/main/css/index.css
+++ b/src/main/css/index.css
@@ -128,6 +128,14 @@
   border-radius: 8px;
 }
 
+.tippy-tooltip.jenkins-theme .parameterBlock {
+  padding-top:10px;
+}
+
+.tippy-tooltip.jenkins-theme .parameters {
+  padding-left:10px;
+}
+
 .tippy-tooltip.jenkins-theme .tooltip-head {
   padding: 5px;
   background: var(--table-background);

--- a/src/main/java/io/jenkins/plugins/view/calendar/event/CalendarEvent.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/event/CalendarEvent.java
@@ -30,6 +30,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import java.util.List;
+import java.util.Map;
 
 @Restricted(NoExternalUse.class)
 public interface CalendarEvent {
@@ -58,4 +59,6 @@ public interface CalendarEvent {
     CalendarEventState getState();
 
     List<StartedCalendarEvent> getLastEvents();
+
+    Map<String, String> getParameters();
 }

--- a/src/main/java/io/jenkins/plugins/view/calendar/service/CalendarEventService.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/service/CalendarEventService.java
@@ -138,7 +138,7 @@ public class CalendarEventService {
                 next.set(Calendar.SECOND, 0);
                 next.set(Calendar.MILLISECOND, 0);
                 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-                final ScheduledCalendarEvent event = calendarEventFactory.createScheduledEvent(job, next, estimatedDuration);
+                final ScheduledCalendarEvent event = calendarEventFactory.createScheduledEvent(job, cronTab.getParameters(), next, estimatedDuration);
                 if (!event.isInRange(inclusionRange)) {
                     break;
                 }
@@ -274,7 +274,7 @@ public class CalendarEventService {
         final Calendar nextStart = cronJobService.getNextStart(job, eventsType);
         if (nextStart != null) {
             final long estimatedDuration = job.getEstimatedDuration();
-            return calendarEventFactory.createScheduledEvent(job, nextStart, estimatedDuration);
+            return calendarEventFactory.createScheduledEvent(job, Collections.emptyMap(), nextStart, estimatedDuration);
         }
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/view/calendar/service/CronWrapper.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/service/CronWrapper.java
@@ -4,13 +4,17 @@ import hudson.scheduler.CronTab;
 import io.jenkins.plugins.extended_timer_trigger.CronTabWrapper;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.GregorianCalendar;
+import java.util.Map;
+
 import org.jenkinsci.plugins.parameterizedscheduler.ParameterizedCronTab;
 
 public abstract class CronWrapper<T> {
     public abstract Calendar ceil(long timeInMillis);
     public abstract Calendar floor(long timeInMillis);
     public abstract T getCronTab();
+    public abstract Map<String, String> getParameters();
 
     public static class ClassicCronTab extends CronWrapper<CronTab> {
         private final CronTab cronTab;
@@ -32,6 +36,11 @@ public abstract class CronWrapper<T> {
         @Override
         public CronTab getCronTab() {
             return cronTab;
+        }
+
+        @Override
+        public Map<String, String> getParameters() {
+            return Collections.emptyMap();
         }
     }
 
@@ -55,6 +64,11 @@ public abstract class CronWrapper<T> {
         @Override
         public ParameterizedCronTab getCronTab() {
             return cronTab;
+        }
+
+        @Override
+        public Map<String, String> getParameters() {
+            return this.cronTab.getParameterValues();
         }
     }
 
@@ -84,6 +98,11 @@ public abstract class CronWrapper<T> {
         @Override
         public CronTabWrapper getCronTab() {
             return cronTab;
+        }
+
+        @Override
+        public Map<String, String> getParameters() {
+            return this.cronTab.getParameters();
         }
     }
 }

--- a/src/main/js/popup.js
+++ b/src/main/js/popup.js
@@ -63,7 +63,8 @@ function buildInfo(event) {
   return $('<div class="tooltip-left"></div>')
     .append($('<b></b>').text(CalendarViewOptions.popupText.build))
     .append($('<div class="timestamp"></div>').text(event.timestampString))
-    .append($('<div class="duration"></div>').text(event.durationString));
+    .append($('<div class="duration"></div>').text(event.durationString))
+    .append((event.parameters && event.parameters.length > 0) ? parameters(event) : '');
 }
 
 function nextScheduledBuild(event, view) {
@@ -89,6 +90,14 @@ function noBuildHistoryEntries() {
 
 function buildHistoryEntries(event, view) {
   return event.builds.map(function(b) { return $('<li></li>').append(build(b, view)); });
+}
+
+function parameters(event) {
+  return $('<div class="parameterBlock"></div>')
+    .append($('<b></b>').text(CalendarViewOptions.popupText.parameters))
+    .append($('<div class="parameters"></div>')
+      .append($('<ul></ul>')
+        .append(event.parameters.map(function(b) { return $('<li></li>').append([b.name, '=', b.value]); }))));
 }
 
 function prevAndNextBuild(event, view) {

--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/events.jelly
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/events.jelly
@@ -38,6 +38,14 @@ THE SOFTWARE.
     "duration": ${event.duration},
     "state": "${event.state.toString().toLowerCase()}",
     "className": "event-result-<j:if test="${event.state == 'FINISHED'}">${event.build.result.toString().toLowerCase()}</j:if><j:if test="${event.state == 'RUNNING'}">${event.job.lastCompletedBuild.result.toString().toLowerCase()}</j:if> event-state-${event.state.toString().toLowerCase()} event-id-${event.id}",
+    "parameters": [
+      <j:forEach var="parameter" items="${event.parameters}" varStatus="parameterLoop">
+        {
+          "name": "<j:out value="${it.jsonEscape(parameter.key)}"/>",
+          "value": "<j:out value="${it.jsonEscape(parameter.value)}"/>"
+        }<j:if test="${!parameterLoop.last}">,</j:if>
+      </j:forEach>
+    ],
     <j:if test="${event.state == 'SCHEDULED' || event.state == 'RUNNING'}">
       <j:if test="${event.state == 'SCHEDULED'}">
       "timestampString": "<j:out value="${%startsIn(event.timestampString)}"/>",

--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main.jelly
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main.jelly
@@ -49,7 +49,8 @@ THE SOFTWARE.
            "buildHistory": "${%Build History}:",
            "buildHistoryEmpty": "${%No past builds}",
            "project": "${%Project}: ",
-           "nextScheduledBuild": "${%Next build}: "
+           "nextScheduledBuild": "${%Next build}: ",
+           "parameters": "${%Parameters}:"
          },
          "names": {
            "monthNames": [

--- a/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main_de.properties
+++ b/src/main/resources/io/jenkins/plugins/view/calendar/CalendarView/main_de.properties
@@ -90,3 +90,4 @@ No\ past\ builds=Keine vergangenen Builds
 This\ build=Dieser Build
 Project=Projekt
 Next\ build=Nächster Build
+Parameters=Parameter

--- a/src/test/java/io/jenkins/plugins/view/calendar/event/CalendarEventFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/view/calendar/event/CalendarEventFactoryTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
@@ -102,7 +103,7 @@ class CalendarEventFactoryTest {
         when(project.getBuildHealth()).thenReturn(health);
 
         Moment now = new Moment();
-        ScheduledCalendarEvent event = getCalendarEventFactory(now).createScheduledEvent(project, start, duration);
+        ScheduledCalendarEvent event = getCalendarEventFactory(now).createScheduledEvent(project, Collections.emptyMap(), start, duration);
         assertThat(event.getJob(), is(project));
         assertThat(event.getTitle(), is("Example Project"));
         assertThat(event.getStart(), is(mom(start)));
@@ -148,63 +149,63 @@ class CalendarEventFactoryTest {
         // MomentRange:       |           |
         // Event:       #####
         Calendar start1 = cal("2018-01-01 00:00:00 UTC");
-        CalendarEvent event1 = getCalendarEventFactory(now).createScheduledEvent(item, start1, hours(6));
+        CalendarEvent event1 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start1, hours(6));
         assertThat(event1.getEnd(), is(mom("2018-01-01 06:00:00 UTC")));
         assertThat(event1.isInRange(range), is(true));
 
         // MomentRange:       |           |
         // Event:                   #####
         Calendar start2 = cal("2018-01-02 00:00:00 UTC");
-        CalendarEvent event2 = getCalendarEventFactory(now).createScheduledEvent(item, start2, hours(6));
+        CalendarEvent event2 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start2, hours(6));
         assertThat(event2.getEnd(), is(mom("2018-01-02 06:00:00 UTC")));
         assertThat(event2.isInRange(range), is(not(true)));
 
         // MomentRange:       |           |
         // Event:   #####
         Calendar start3 = cal("2017-12-31 18:00:00 UTC");
-        CalendarEvent event3 = getCalendarEventFactory(now).createScheduledEvent(item, start3, hours(6));
+        CalendarEvent event3 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start3, hours(6));
         assertThat(event3.getEnd(), is(mom("2018-01-01 00:00:00 UTC")));
         assertThat(event3.isInRange(range), is(not(true)));
 
         // MomentRange:       |           |
         // Event:               #####
         Calendar start4 = cal("2018-01-01 18:00:00 UTC");
-        CalendarEvent event4 = getCalendarEventFactory(now).createScheduledEvent(item, start4, hours(6));
+        CalendarEvent event4 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start4, hours(6));
         assertThat(event4.getEnd(), is(mom("2018-01-02 00:00:00 UTC")));
         assertThat(event4.isInRange(range), is(true));
 
         // MomentRange:       |           |
         // Event:     #####
         Calendar start5 = cal("2017-12-31 21:00:00 UTC");
-        CalendarEvent event5 = getCalendarEventFactory(now).createScheduledEvent(item, start5, hours(6));
+        CalendarEvent event5 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start5, hours(6));
         assertThat(event5.getEnd(), is(mom("2018-01-01 03:00:00 UTC")));
         assertThat(event5.isInRange(range), is(true));
 
         // MomentRange:       |           |
         // Event:                 #####
         Calendar start6 = cal("2018-01-01 21:00:00 UTC");
-        CalendarEvent event6 = getCalendarEventFactory(now).createScheduledEvent(item, start6, hours(6));
+        CalendarEvent event6 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start6, hours(6));
         assertThat(event6.getEnd(), is(mom("2018-01-02 03:00:00 UTC")));
         assertThat(event6.isInRange(range), is(true));
 
         // MomentRange:       |           |
         // Event:                     #####
         Calendar start7 = cal("2018-01-02 03:00:00 UTC");
-        CalendarEvent event7 = getCalendarEventFactory(now).createScheduledEvent(item, start7, hours(6));
+        CalendarEvent event7 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start7, hours(6));
         assertThat(event7.getEnd(), is(mom("2018-01-02 09:00:00 UTC")));
         assertThat(event7.isInRange(range), is(not(true)));
 
         // MomentRange:       |           |
         // Event: #####
         Calendar start8 = cal("2017-12-31 03:00:00 UTC");
-        CalendarEvent event8 = getCalendarEventFactory(now).createScheduledEvent(item, start8, hours(6));
+        CalendarEvent event8 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start8, hours(6));
         assertThat(event8.getEnd(), is(mom("2017-12-31 09:00:00 UTC")));
         assertThat(event8.isInRange(range), is(not(true)));
 
         // MomentRange:       |           |
         // Event:      ###############
         Calendar start9 = cal("2017-12-31 21:00:00 UTC");
-        CalendarEvent event9 = getCalendarEventFactory(now).createScheduledEvent(item, start9, hours(30));
+        CalendarEvent event9 = getCalendarEventFactory(now).createScheduledEvent(item, Collections.emptyMap(), start9, hours(30));
         assertThat(event9.getEnd(), is(mom("2018-01-02 03:00:00 UTC")));
         assertThat(event9.isInRange(range), is(true));
     }


### PR DESCRIPTION
Implementation of #108 - Tooltip shows job parameters

Finished and running jobs show the actually used parameters, even if these are no longer configured on the jobs.
Scheduled jobs show the configured parameters, using any defaults if they are not explicitly set in the CRON.
