### PR TITLE
Method 'jsonEscape' internally called 'escapeEcma', which escapes characters that should NOT be esacped in JSON

### DIFF
--- a/src/main/java/io/jenkins/plugins/view/calendar/CalendarView.java
+++ b/src/main/java/io/jenkins/plugins/view/calendar/CalendarView.java
@@ -524,7 +524,7 @@ public class CalendarView extends ListView {
   }
 
   public String jsonEscape(final String text) {
-    return StringEscapeUtils.escapeEcmaScript(text);
+    return StringEscapeUtils.escapeJson(text);
   }
 
   @Extension


### PR DESCRIPTION
This fixes #209. Any and all characters that should not be escaped in JSON, should now be correctly transported to the UI.